### PR TITLE
Fix deprecation warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.13",
       "license": "MIT",
       "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.1.0",
         "ajv": "8.11.2",
         "ajv-errors": "3.0.0",
         "ajv-formats": "2.1.1",
@@ -26,9 +27,9 @@
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
-      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.0.tgz",
+      "integrity": "sha512-teB30tFooE3iQs2HQIKJ02D8UZA1Xy1zaczzhUjJs0CymYxeC0g+y5rCY2p8NHBM6DBUVoR8rSM4kHLj1WE9mQ==",
       "dependencies": {
         "@jsdevtools/ono": "^7.1.3",
         "@types/json-schema": "^7.0.6",
@@ -651,6 +652,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/json-schema-ref-parser/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/json-schema-traverse": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/willfarrell/ajv-cmd",
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^9.1.0",
     "ajv": "8.11.2",
     "ajv-errors": "3.0.0",
     "ajv-formats": "2.1.1",
@@ -46,6 +47,5 @@
     "commander": "9.4.1",
     "esbuild": "0.15.17",
     "fast-uri": "2.1.0",
-    "json-schema-ref-parser": "9.0.9"
   }
 }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
npm WARN deprecated json-schema-ref-parser@9.0.9: Please switch to @apidevtools/json-schema-ref-parser
```