### PR TITLE
fix: use 'husky || true' in prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
 		}
 	},
 	"scripts": {
-		"prepare": "husky",
+		"prepare": "husky || true",
 		"prepublishOnly": "npm run build",
 		"build": "npm run build:index && npm run build:compile && npm run build:ftl && npm run build:transpile && npm run build:validate && npm run build:sast",
 		"build:index": "./node_modules/.bin/esbuild index.js --platform=node --format=cjs  --target=node18 --allow-overwrite --outfile=index.cjs",


### PR DESCRIPTION
## Summary
- Change `"prepare": "husky"` to `"prepare": "husky || true"`
- Prevents `npm ci` from failing in environments where husky isn't installed (e.g. production Docker builds, CI steps using `--omit=dev`)

## Test plan
- [ ] Verify `npm ci` still installs husky hooks in dev environments
- [ ] Verify `npm ci --omit=dev` no longer fails on missing husky