### PR TITLE
chore: add .npmignore to exclude license files from npm pack

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+license.json
+license.template


### PR DESCRIPTION
## Summary
- Add `.npmignore` listing `license.json` and `license.template`
- These files are used by `license-check-and-add` during development but shouldn't be published to npm

## Test plan
- [ ] Run `npm pack --dry-run` and confirm `license.json` and `license.template` are not listed